### PR TITLE
Use automated integration tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: terraform
-  directory: "/tests/no_create"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
 - package-ecosystem: terraform
   directory: "/tests/create_rr_association"
   schedule:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,6 @@ pull_request_rules:
     conditions:
       - author~=dependabot\[bot\]|dependabot-preview\[bot\]
       - status-success=Travis CI - Pull Request
-      - label!=terraform
     actions:
       review:
         type: APPROVE

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,32 @@ language: minimal
 
 stages:
   - lint
+  - test
   - deploy
 
 if: branch = master OR type = pull_request
+
+before_install:
+  - tmpdaemon=$(mktemp)
+  - sudo jq '."registry-mirrors" += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmpdaemon"
+  - sudo mv "$tmpdaemon" /etc/docker/daemon.json
+  - sudo systemctl daemon-reload
+  - sudo systemctl restart docker
+  - docker system info
 
 jobs:
   include:
     - stage: lint
       name: Project Syntax Verification
       script: make docker/run target=lint
+    - stage: test
+      name: Apply Terraform test configs in mockstack
+      install:
+        - make docker-compose/install
+        - make mockstack/up
+      script: make mockstack/pytest
+      after_script:
+        - make mockstack/clean
     - stage: deploy
       if: branch = master AND type = push AND repo = plus3it/terraform-aws-tardigrade-route53-rr-association
       before_script:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 SHELL := /bin/bash
+ONLY_MOTO := true
 
 include $(shell test -f .tardigrade-ci || curl -sSL -o .tardigrade-ci "https://raw.githubusercontent.com/plus3it/tardigrade-ci/master/bootstrap/Makefile.bootstrap"; echo .tardigrade-ci)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ make terraform/pytest PYTEST_ARGS="-v --nomock"
 For automated testing, PYTEST_ARGS is optional and no profile is needed:
 
 ```
+make mockstack/up
 make terraform/pytest PYTEST_ARGS="-v"
+make mockstack/clean
 ```
 
 <!-- BEGIN TFDOCS -->

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ export AWS_PROFILE=xxx
 make terraform/pytest PYTEST_ARGS="-v --nomock"
 ```
 
+For automated testing, PYTEST_ARGS is optional and no profile is needed:
+
+```
+make terraform/pytest PYTEST_ARGS="-v"
+```
+
 <!-- BEGIN TFDOCS -->
 ## Requirements
 


### PR DESCRIPTION
Uses tardigrade-ci's ability to run automated integration tests against a mock AWS stack.